### PR TITLE
Added KeyError check when trying to access access_token in params

### DIFF
--- a/falcon_auth0/__init__.py
+++ b/falcon_auth0/__init__.py
@@ -203,9 +203,16 @@ class Auth0Middleware(AbstractBaseMiddleware):
         _access_token = req.get_header('X-Auth-Token', None)
         if _access_token is None:
             if req.method in ['HEAD', 'GET']:
-                logger.info('Auth Token found in query string.')
-                _access_token = (req.params.pop(_environment_config.get('access_token', 'access_token')) if self.__digest
-                                    else req.params.get(_environment_config.get('access_token', 'access_token')))
+                access_token_key = _environment_config.get('access_token', 'access_token')
+                try:
+                    _access_token = (req.params.pop(access_token_key) if self.__digest
+                                 else req.params.get(access_token_key))
+                    logger.info('Auth Token found in query string.')
+
+                except KeyError:
+                    logger.info('Auth Token NOT found in query string.')
+                    _access_token = None
+
             else:
                 logger.info('Auth Token found in request body.')
                 _access_token = (req.context.pop(_environment_config.get('access_token', 'access_token')) if self.__digest


### PR DESCRIPTION
When doing GET or HEAD requests with Authentication, the code  looks for the key `access_token` in the `req.params` field. This field is a normal dict, which means that if `access_token` is not present, we get a KeyError. This fix returns an access_token None when the key is not there. **Im not sure whether this is good practise security wise though!**

It's not an issue on POST or other requests, because there the `access_token` is consumed form the `req.context`, which is not a normal dict, but a falcon class `falcon.util.structures.Context` which has implementations for `get()` and `pop()` that return None when the key is not there.